### PR TITLE
Decouple Startup.cs

### DIFF
--- a/Galore.WebApi/Extensions/AutoMapperExtension.cs
+++ b/Galore.WebApi/Extensions/AutoMapperExtension.cs
@@ -1,0 +1,21 @@
+using System;
+using Galore.Models.Tape;
+using Microsoft.AspNetCore.Builder;
+
+namespace Galore.WebApi.Extensions
+{
+    public static class AutoMapperExtension
+    {
+        public static void ConfigureAutoMapper(this IApplicationBuilder app)
+        {
+            AutoMapper.Mapper.Initialize( c => {
+                c.CreateMap<Tape, TapeDTO>();
+                c.CreateMap<TapeDTO, Tape>();
+                c.CreateMap<Tape, TapeDetailDTO>();
+                c.CreateMap<TapeInputModel, Tape>()
+                    .ForMember(t => t.DateCreated, opt => opt.UseValue(DateTime.Now))
+                    .ForMember(t => t.DateModified, opt => opt.UseValue(DateTime.Now));
+            });
+        }
+    }
+}

--- a/Galore.WebApi/Extensions/DIExtensions.cs
+++ b/Galore.WebApi/Extensions/DIExtensions.cs
@@ -1,0 +1,29 @@
+using Galore.Repositories.Context;
+using Galore.Repositories.Implementations;
+using Galore.Repositories.Interfaces;
+using Galore.Services.implementations;
+using Galore.Services.Implementations;
+using Galore.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Galore.WebApi.Extensions
+{
+    public static class DIExtension
+    {
+        public static void ConfigureDependencyInjections(this IServiceCollection services)
+        {
+            // Dependency Injections for all services
+            services.AddTransient<IUserService, UserService>();
+            services.AddTransient<ITapeService, TapeService>();
+            services.AddTransient<ILoanService, LoanService>();
+            services.AddTransient<IReviewService, ReviewService>();
+            services.AddTransient<IRecommendationService, RecommendationService>();
+            services.AddTransient<ILogService, LogService>();
+            // Dependency Injections for all repositories
+            services.AddTransient<IUserRepository, UserRepository>();
+            services.AddTransient<ITapeRepository, TapeRepository>();
+            services.AddTransient<ILoanRepository, LoanRepository>();
+            services.AddTransient<IMockDatabaseContext, MockDatabaseContext>();   
+        }
+    }
+}

--- a/Galore.WebApi/Extensions/DatabaseExtension.cs
+++ b/Galore.WebApi/Extensions/DatabaseExtension.cs
@@ -1,0 +1,16 @@
+using Galore.Repositories.Context;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Galore.WebApi.Extensions
+{
+    public static class DatabaseExtension
+    {
+        public static void ConfigureDatabase(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddDbContext<UserContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection"), x => x.MigrationsAssembly("Galore.WebApi")));
+        }
+    }
+}

--- a/Galore.WebApi/Startup.cs
+++ b/Galore.WebApi/Startup.cs
@@ -1,25 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Galore.Models.Tape;
-using Galore.Repositories.Context;
-using Galore.Repositories.Implementations;
-using Galore.Repositories.Interfaces;
-using Galore.Services.implementations;
-using Galore.Services.Interfaces;
+﻿using System.Threading.Tasks;
 using Galore.WebApi.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using AutoMapper;
-using Galore.Services.Implementations;
 
 namespace Galore.WebApi
 {
@@ -36,22 +23,8 @@ namespace Galore.WebApi
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
-
-            services.AddDbContext<UserContext>(options =>
-            options.UseNpgsql(Configuration.GetConnectionString("DefaultConnection"), x => x.MigrationsAssembly("Galore.WebApi")));
-
-            services.AddTransient<IUserService, UserService>();
-            services.AddTransient<ITapeService, TapeService>();
-            services.AddTransient<ILoanService, LoanService>();
-            services.AddTransient<IReviewService, ReviewService>();
-            services.AddTransient<IRecommendationService, RecommendationService>();
-            services.AddTransient<ILogService, LogService>();
-
-            services.AddTransient<IUserRepository, UserRepository>();
-            services.AddTransient<ITapeRepository, TapeRepository>();
-            services.AddTransient<ILoanRepository, LoanRepository>();
-            services.AddTransient<IMockDatabaseContext, MockDatabaseContext>();
-
+            services.ConfigureDependencyInjections();
+            services.ConfigureDatabase(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -69,16 +42,7 @@ namespace Galore.WebApi
             app.ConfigureExceptionHandler();
             app.UseHttpsRedirection();
             app.UseMvc();
-
-            AutoMapper.Mapper.Initialize( c => {
-                c.CreateMap<Tape, TapeDTO>();
-                c.CreateMap<TapeDTO, Tape>();
-                c.CreateMap<Tape, TapeDetailDTO>();
-                c.CreateMap<TapeInputModel, Tape>()
-                    .ForMember(t => t.DateCreated, opt => opt.UseValue(DateTime.Now))
-                    .ForMember(t => t.DateModified, opt => opt.UseValue(DateTime.Now));
-            });
-
+            app.ConfigureAutoMapper();
         }
     }
 }


### PR DESCRIPTION
Decoupled Startup.cs

Added more extension classes to make Startup.cs less crowded so now we have one file for exception handling, one for automapper, one for database, one for dependency injections and we can keep on adding new files when we need to add new services to the api